### PR TITLE
Small fix: stdc library got moved sometime in the last 8 years

### DIFF
--- a/source/mrss.d
+++ b/source/mrss.d
@@ -1,5 +1,5 @@
 module d_rss.mrss;
-import std.c.time;
+import core.stdc.time;
 
 /* mRss - Copyright (C) 2005-2007 bakunin - Andrea Marchesini 
  *                                    <bakunin@autistici.org>


### PR DESCRIPTION
This one line change makes the package compile with the newest dmd